### PR TITLE
Bump arangojs minor version

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "author": "Rob Taylor <roboncode@gmail.com> (https://www.linkedin.com/in/roboncode/)",
   "license": "MIT",
   "dependencies": {
-    "arangojs": "6.10.0",
+    "arangojs": "6.13.0",
     "colors": "1.3.3",
     "dotenv": "6.2.0",
     "pluralize": "^7.0.0",


### PR DESCRIPTION
Newest arangojs version 6.13.0 https://github.com/arangodb/arangojs/releases/tag/v6.13.0 is having a patched memory leak https://github.com/arangodb/arangojs/issues/601